### PR TITLE
Fix undefined variable `class` when rendering non-BNET friends w/ class colors

### DIFF
--- a/FriendGroups.lua
+++ b/FriendGroups.lua
@@ -102,7 +102,7 @@ local function FriendGroups_UpdateFriendButton(button)
 			end
 
 			if FriendGroups_SavedVars.colour_classes then
-				nameColor = ClassColourCode(class,true);
+				nameColor = ClassColourCode(info.className, true);
 			else
 				nameColor = FRIENDS_WOW_NAME_COLOR;
 			end


### PR DESCRIPTION
We use `C_FriendList.GetFriendInfoByIndex` to get information about
each non-BNET friend in our friend list and store it in the `info`
table. To get class colors, we should be referencing `info.className`
rather than the undefined local variable `class`.