### PR TITLE
Render offline friends

### DIFF
--- a/FriendGroups.lua
+++ b/FriendGroups.lua
@@ -110,7 +110,7 @@ local function FriendGroups_UpdateFriendButton(button)
 		else
 			button.background:SetColorTexture(FRIENDS_OFFLINE_BACKGROUND_COLOR.r, FRIENDS_OFFLINE_BACKGROUND_COLOR.g, FRIENDS_OFFLINE_BACKGROUND_COLOR.b, FRIENDS_OFFLINE_BACKGROUND_COLOR.a);
 			button.status:SetTexture(FRIENDS_TEXTURE_OFFLINE);
-			nameText = name;
+			nameText = info.name;
 			nameColor = FRIENDS_GRAY_COLOR;
 		end
 		infoText = info.mobile and LOCATION_MOBILE_APP or info.area;

--- a/FriendGroups.lua
+++ b/FriendGroups.lua
@@ -102,7 +102,7 @@ local function FriendGroups_UpdateFriendButton(button)
 			end
 
 			if FriendGroups_SavedVars.colour_classes then
-				nameColor = ClassColourCode(class,true);
+				nameColor = ClassColourCode(info.className, true);
 			else
 				nameColor = FRIENDS_WOW_NAME_COLOR;
 			end


### PR DESCRIPTION
When rendering the row for an offline, non-BNET friend, the
variable `nameText` was being set to the value of the local
variable `name` variable. `name` was never defined and therefore
had a value of `nil`.

Apparently, setting the text to `nil` causes that entire line to
appear blank (no textures, no nothing). We should get the friend's
name from `info.name` instead.